### PR TITLE
chore(release): v0.0.7, upgrade @lifi/types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/tenderlysim",
-  "version": "0.0.7-beta.0",
+  "version": "0.0.7",
   "description": "Helpers to simulate lifi quotes",
   "author": {
     "name": "LI.FI",
@@ -65,7 +65,7 @@
   },
   "packageManager": "pnpm@9.15.0",
   "dependencies": {
-    "@lifi/types": "^17.0.0-beta.6",
+    "@lifi/types": "^17.0.0",
     "@types/memoizee": "^0.4.11",
     "axios": "^1.7.7",
     "ethers": "^6.13.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifi/tenderlysim",
-  "version": "0.0.6",
+  "version": "0.0.7-beta.0",
   "description": "Helpers to simulate lifi quotes",
   "author": {
     "name": "LI.FI",
@@ -65,7 +65,7 @@
   },
   "packageManager": "pnpm@9.15.0",
   "dependencies": {
-    "@lifi/types": "^16.10.0",
+    "@lifi/types": "^17.0.0-beta.6",
     "@types/memoizee": "^0.4.11",
     "axios": "^1.7.7",
     "ethers": "^6.13.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lifi/types':
-        specifier: ^16.10.0
-        version: 16.10.0
+        specifier: ^17.0.0-beta.6
+        version: 17.0.0-beta.6
       '@types/memoizee':
         specifier: ^0.4.11
         version: 0.4.11
@@ -504,8 +504,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@lifi/types@16.10.0':
-    resolution: {integrity: sha512-bwlhO7rwb2vXCnHkbjLQSUQciAG6pF0a4I7eQ1Gnfuedm4vHTjmWoBRwAK5GjgwL9k4Qokppt1OYxeCNXHsxcg==}
+  '@lifi/types@17.0.0-beta.6':
+    resolution: {integrity: sha512-cpGM0e8GfCH3HPbrDiWR4qNWXGfrCkGLPYg0MAEFEShtDshtrA4qOeMcrkU+GyMnG3CYEg4sBgGNlANWLxCDtA==}
 
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
@@ -4173,7 +4173,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@lifi/types@16.10.0': {}
+  '@lifi/types@17.0.0-beta.6': {}
 
   '@noble/curves@1.2.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lifi/types':
-        specifier: ^17.0.0-beta.6
-        version: 17.0.0-beta.6
+        specifier: ^17.0.0
+        version: 17.0.0
       '@types/memoizee':
         specifier: ^0.4.11
         version: 0.4.11
@@ -504,8 +504,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@lifi/types@17.0.0-beta.6':
-    resolution: {integrity: sha512-cpGM0e8GfCH3HPbrDiWR4qNWXGfrCkGLPYg0MAEFEShtDshtrA4qOeMcrkU+GyMnG3CYEg4sBgGNlANWLxCDtA==}
+  '@lifi/types@17.0.0':
+    resolution: {integrity: sha512-+zjnkg+abGkfmGQknQFZq2HwhvvDf5RxHOLw5x69A7oILLbgm/Kkei2qCP6GLBt2z4OvMJD3XnxwBlOGcvqPMQ==}
 
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
@@ -4173,7 +4173,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@lifi/types@17.0.0-beta.6': {}
+  '@lifi/types@17.0.0': {}
 
   '@noble/curves@1.2.0':
     dependencies:


### PR DESCRIPTION
upgrades @lifi/types to the next major-version release