### PR TITLE
chore: update types

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "packageManager": "pnpm@9.15.0",
   "dependencies": {
-    "@lifi/types": "^17.23.0",
+    "@lifi/types": "^17.26.0",
     "@types/memoizee": "^0.4.11",
     "axios": "^1.7.7",
     "ethers": "^6.13.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lifi/types':
-        specifier: ^17.23.0
-        version: 17.23.0(typescript@5.3.3)
+        specifier: ^17.26.0
+        version: 17.26.0(typescript@5.3.3)
       '@types/memoizee':
         specifier: ^0.4.11
         version: 0.4.11
@@ -507,8 +507,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@lifi/types@17.23.0':
-    resolution: {integrity: sha512-Gv475IPlJeIXOYOe6FM4gaJoKedXVnQAhuK50R44QbTc+olHDIFEDR1diafaMSHweMdWF0YbbKzI/r98CcgXiQ==}
+  '@lifi/types@17.26.0':
+    resolution: {integrity: sha512-lfd+YNc5ApmNTGnn5V8a/3rNU8odBMdh7CTJNToPeuEnsXlAxEFKN6d1/ou7PH9MLvtrfBbypo+j3tzFT5XDgQ==}
 
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
@@ -4245,7 +4245,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@lifi/types@17.23.0(typescript@5.3.3)':
+  '@lifi/types@17.26.0(typescript@5.3.3)':
     dependencies:
       viem: 2.31.7(typescript@5.3.3)
     transitivePeerDependencies:


### PR DESCRIPTION
Updating types to prevent missmatch of CoinKey in different packages