### PR TITLE
chore: switch to npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,6 +27,9 @@ jobs:
           prerelease: false
 
   publish:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,4 +54,4 @@ jobs:
           pnpm publish --no-git-checks --access public \
           ${{ contains(github.ref_name, 'alpha') && '--tag alpha' || contains(github.ref_name, 'beta') && '--tag beta' || '' }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Switch to npm trusted publishing via OIDC. Remove NPM_TOKEN secret from publish workflow.