### PR TITLE
feat: add new chain Lighter

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@types/node": "^22.0.0",
     "@typescript-eslint/eslint-plugin": "^8.58.1",
     "@typescript-eslint/parser": "^8.58.1",
-    "typescript-eslint": "^8.58.1",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
@@ -65,11 +64,12 @@
     "standard-version": "^9.5.0",
     "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "typescript-eslint": "^8.58.1"
   },
   "packageManager": "pnpm@10.14.0",
   "dependencies": {
-    "@lifi/types": "17.76.0",
+    "@lifi/types": "17.78.0",
     "@types/memoizee": "^0.4.12",
     "axios": "^1.15.0",
     "ethers": "^6.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lifi/types':
-        specifier: 17.76.0
-        version: 17.76.0(typescript@6.0.2)
+        specifier: 17.78.0
+        version: 17.78.0(typescript@6.0.2)
       '@types/memoizee':
         specifier: ^0.4.12
         version: 0.4.12
@@ -654,8 +654,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@lifi/types@17.76.0':
-    resolution: {integrity: sha512-lu1g9Vw650zqY5KYFSQztgrm1LzLgOIJcABxFzAN+S/n0ujL+MIYn0pjI111zUupBzZ5XKLjGvHQ6uT2EjkgKQ==}
+  '@lifi/types@17.78.0':
+    resolution: {integrity: sha512-ifuX7MAmoGp5dZN+6cotiQ/yhNAierkQU+ElwJ4O4Yqaaba4czl02p0JKpv6g9xxKWkMS4VZjOnmwHWgwAX6CA==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -4878,7 +4878,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@lifi/types@17.76.0(typescript@6.0.2)':
+  '@lifi/types@17.78.0(typescript@6.0.2)':
     dependencies:
       viem: 2.33.3(typescript@6.0.2)
     transitivePeerDependencies:


### PR DESCRIPTION
Bumps @lifi/types to 17.78.0 — required for ChainId.LTR (Lighter) support.

No release commit on this branch yet — the stable release (0.0.62) will be cut on main after this PR merges.